### PR TITLE
Update Travis CI to test latest NodeJS v5.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'stable'
+  - '5'
   - '4'
   - '0.12'
   - '0.10'


### PR DESCRIPTION
Using `stable` only gets you NodeJS v5.0.0, switching to `5` gets the latest "stable" which is currently v5.4.0
